### PR TITLE
Improve OCR handling and address extraction

### DIFF
--- a/src/hooks/useGeocode.ts
+++ b/src/hooks/useGeocode.ts
@@ -8,7 +8,7 @@ export const useGeocode = () => {
   useKakaoLoader({ appkey: import.meta.env.VITE_KAKAO_APP_KEY, libraries: ['services'] })
 
   const geocode = async (address: string) => {
-    const kakao = window.kakao
+    const kakao = window.kakao as any
     if (!geocoderRef.current) {
       geocoderRef.current = new kakao.maps.services.Geocoder()
     }

--- a/src/hooks/useOcr.ts
+++ b/src/hooks/useOcr.ts
@@ -28,7 +28,8 @@ export const useOcr = () => {
 
     setLoading(false)
 
-    const text = data.text.replace(/\s+/g, ' ')
+    console.log(data.text)
+    const text = data.text.replace(/\s+/g, ' ').trim()
     console.log(text)
 
     return extractAddresses(text)

--- a/src/lib/addrRegex.ts
+++ b/src/lib/addrRegex.ts
@@ -1,5 +1,5 @@
-// 간단한 한국어 도로명 주소 패턴 추출
-const addrPattern = /[가-힣0-9\s-]+?(시|도)\s[가-힣0-9\s-]+?(구|군)\s[가-힣0-9\s-]+?(로|길|동)\s?[0-9-]*/g
+// 구/시/군 + 도로명/길 + 번지 형태 추출
+const addrPattern = /\b[가-힣]+(?:구|시|군)\s*[가-힣0-9]+(?:로|길)\s*\d+(?:-\d+)?/g
 
 export const extractAddresses = (text: string): string[] => {
   const matches = text.match(addrPattern)

--- a/src/types/react-kakao-maps-sdk.d.ts
+++ b/src/types/react-kakao-maps-sdk.d.ts
@@ -1,0 +1,8 @@
+declare module 'react-kakao-maps-sdk'
+
+declare global {
+  interface Window {
+    kakao: unknown
+  }
+}
+export {}

--- a/src/types/react-kakao-maps-sdk.d.ts
+++ b/src/types/react-kakao-maps-sdk.d.ts
@@ -1,4 +1,9 @@
-declare module 'react-kakao-maps-sdk'
+/* eslint-disable @typescript-eslint/no-explicit-any */
+declare module 'react-kakao-maps-sdk' {
+  export const Map: any
+  export const MapMarker: any
+  export function useKakaoLoader(options: any): void
+}
 
 declare global {
   interface Window {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -21,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- use Tesseract.js worker with progress callbacks and text normalization
- refine Korean address regex
- declare missing react-kakao-maps-sdk module and kakao global types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9005528e083209e56b9d92f51d8eb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved OCR to a background worker for smoother performance and more reliable progress updates.
  * Normalized recognized text to reduce noise and improve downstream extraction results.
* **Bug Fixes**
  * Improved Korean address detection with a more precise matching pattern, reducing false positives and whitespace issues.
* **Chores**
  * Added TypeScript declarations for the Kakao Maps SDK to improve editor support.
  * Updated TypeScript config to include custom type roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->